### PR TITLE
Refactor SLO provisioning into reusable module

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,6 +1,6 @@
 config {
-  module = true
-  force  = false
+  call_module_type = "all"
+  force            = false
 }
 
 plugin "terraform" {

--- a/main.tf
+++ b/main.tf
@@ -14,63 +14,24 @@ provider "dynatrace" {
   dt_api_token = var.dynatrace_api_token
 }
 
-# Latency SLO
-resource "dynatrace_slo" "todoservice_latency" {
-  name        = "${var.service_name} - Latency"
-  disabled    = false
-  description = "Measures the latency performance of ${var.service_name}"
-  evaluation  = "AGGREGATE"
-  target      = var.latency_target
-  warning     = var.latency_warning
-  timeframe   = var.timeframe
+module "slo_service" {
+  source = "./modules/slo_service"
 
-  metric_expression = "(100)*(builtin:service.response.time:splitBy():percentile(${var.latency_percentile}))/(${var.latency_threshold_ms})"
-  metric_name       = "latency_slo"
+  service_name           = var.service_name
+  timeframe              = var.timeframe
+  latency_target         = var.latency_target
+  latency_warning        = var.latency_warning
+  latency_threshold_ms   = var.latency_threshold_ms
+  latency_percentile     = var.latency_percentile
+  availability_target    = var.availability_target
+  availability_warning   = var.availability_warning
+  traffic_target         = var.traffic_target
+  traffic_warning        = var.traffic_warning
+  traffic_threshold_rpm  = var.traffic_threshold_rpm
+  error_rate_target      = var.error_rate_target
+  error_rate_warning     = var.error_rate_warning
 }
 
-# Availability SLO
-resource "dynatrace_slo" "todoservice_availability" {
-  name        = "${var.service_name} - Availability"
-  disabled    = false
-  description = "Measures the availability of ${var.service_name} based on success rate"
-  evaluation  = "AGGREGATE"
-  target      = var.availability_target
-  warning     = var.availability_warning
-  timeframe   = var.timeframe
-
-  metric_expression = "(100)*((builtin:service.requestCount.total:splitBy():sum)-(builtin:service.errors.total.count:splitBy():sum))/(builtin:service.requestCount.total:splitBy():sum)"
-  metric_name       = "availability_slo"
-}
-
-# Traffic SLO (Throughput)
-resource "dynatrace_slo" "todoservice_traffic" {
-  name        = "${var.service_name} - Traffic"
-  disabled    = false
-  description = "Monitors traffic throughput for ${var.service_name}"
-  evaluation  = "AGGREGATE"
-  target      = var.traffic_target
-  warning     = var.traffic_warning
-  timeframe   = var.timeframe
-
-  metric_expression = "(100)*(builtin:service.requestCount.total:splitBy():count:rate(1m))/(${var.traffic_threshold_rpm})"
-  metric_name       = "traffic_slo"
-}
-
-# Error Rate SLO
-resource "dynatrace_slo" "todoservice_errors" {
-  name        = "${var.service_name} - Error Rate"
-  disabled    = false
-  description = "Tracks the error rate for ${var.service_name}"
-  evaluation  = "AGGREGATE"
-  target      = var.error_rate_target
-  warning     = var.error_rate_warning
-  timeframe   = var.timeframe
-
-  metric_expression = "(100)-((100)*(builtin:service.errors.total.count:splitBy():sum)/(builtin:service.requestCount.total:splitBy():sum))"
-  metric_name       = "error_rate_slo"
-}
-
-# HTTP Synthetic Monitor
 resource "dynatrace_http_monitor" "todoservice_uptime" {
   name      = "${var.service_name} - Uptime Check"
   enabled   = true

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.0.0"
 
   required_providers {
     dynatrace = {

--- a/modules/slo_service/main.tf
+++ b/modules/slo_service/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.0.0"
 
   required_providers {
     dynatrace = {

--- a/modules/slo_service/main.tf
+++ b/modules/slo_service/main.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.0"
+
   required_providers {
     dynatrace = {
       source  = "dynatrace-oss/dynatrace"

--- a/modules/slo_service/main.tf
+++ b/modules/slo_service/main.tf
@@ -1,0 +1,51 @@
+resource "dynatrace_slo" "latency" {
+  name        = "${var.service_name} - Latency"
+  disabled    = false
+  description = "Measures the latency performance of ${var.service_name}"
+  evaluation  = "AGGREGATE"
+  target      = var.latency_target
+  warning     = var.latency_warning
+  timeframe   = var.timeframe
+
+  metric_expression = "(100)*(builtin:service.response.time:splitBy():percentile(${var.latency_percentile}))/(${var.latency_threshold_ms})"
+  metric_name       = "latency_slo"
+}
+
+resource "dynatrace_slo" "availability" {
+  name        = "${var.service_name} - Availability"
+  disabled    = false
+  description = "Measures the availability of ${var.service_name} based on success rate"
+  evaluation  = "AGGREGATE"
+  target      = var.availability_target
+  warning     = var.availability_warning
+  timeframe   = var.timeframe
+
+  metric_expression = "(100)*((builtin:service.requestCount.total:splitBy():sum)-(builtin:service.errors.total.count:splitBy():sum))/(builtin:service.requestCount.total:splitBy():sum)"
+  metric_name       = "availability_slo"
+}
+
+resource "dynatrace_slo" "traffic" {
+  name        = "${var.service_name} - Traffic"
+  disabled    = false
+  description = "Monitors traffic throughput for ${var.service_name}"
+  evaluation  = "AGGREGATE"
+  target      = var.traffic_target
+  warning     = var.traffic_warning
+  timeframe   = var.timeframe
+
+  metric_expression = "(100)*(builtin:service.requestCount.total:splitBy():count:rate(1m))/(${var.traffic_threshold_rpm})"
+  metric_name       = "traffic_slo"
+}
+
+resource "dynatrace_slo" "errors" {
+  name        = "${var.service_name} - Error Rate"
+  disabled    = false
+  description = "Tracks the error rate for ${var.service_name}"
+  evaluation  = "AGGREGATE"
+  target      = var.error_rate_target
+  warning     = var.error_rate_warning
+  timeframe   = var.timeframe
+
+  metric_expression = "(100)-((100)*(builtin:service.errors.total.count:splitBy():sum)/(builtin:service.requestCount.total:splitBy():sum))"
+  metric_name       = "error_rate_slo"
+}

--- a/modules/slo_service/main.tf
+++ b/modules/slo_service/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    dynatrace = {
+      source  = "dynatrace-oss/dynatrace"
+      version = "~> 1.0"
+    }
+  }
+}
+
 resource "dynatrace_slo" "latency" {
   name        = "${var.service_name} - Latency"
   disabled    = false

--- a/modules/slo_service/outputs.tf
+++ b/modules/slo_service/outputs.tf
@@ -1,0 +1,31 @@
+output "latency" {
+  description = "Latency SLO resource"
+  value = {
+    id   = dynatrace_slo.latency.id
+    name = dynatrace_slo.latency.name
+  }
+}
+
+output "availability" {
+  description = "Availability SLO resource"
+  value = {
+    id   = dynatrace_slo.availability.id
+    name = dynatrace_slo.availability.name
+  }
+}
+
+output "traffic" {
+  description = "Traffic SLO resource"
+  value = {
+    id   = dynatrace_slo.traffic.id
+    name = dynatrace_slo.traffic.name
+  }
+}
+
+output "errors" {
+  description = "Error rate SLO resource"
+  value = {
+    id   = dynatrace_slo.errors.id
+    name = dynatrace_slo.errors.name
+  }
+}

--- a/modules/slo_service/variables.tf
+++ b/modules/slo_service/variables.tf
@@ -1,0 +1,64 @@
+variable "service_name" {
+  description = "Name of the service to create SLOs for"
+  type        = string
+}
+
+variable "timeframe" {
+  description = "Timeframe for SLO evaluation"
+  type        = string
+}
+
+variable "latency_target" {
+  description = "Target percentage for latency SLO"
+  type        = number
+}
+
+variable "latency_warning" {
+  description = "Warning threshold for latency SLO"
+  type        = number
+}
+
+variable "latency_threshold_ms" {
+  description = "Latency threshold in milliseconds"
+  type        = number
+}
+
+variable "latency_percentile" {
+  description = "Percentile to use for latency measurement"
+  type        = number
+}
+
+variable "availability_target" {
+  description = "Target percentage for availability SLO"
+  type        = number
+}
+
+variable "availability_warning" {
+  description = "Warning threshold for availability SLO"
+  type        = number
+}
+
+variable "traffic_target" {
+  description = "Target percentage for traffic throughput SLO"
+  type        = number
+}
+
+variable "traffic_warning" {
+  description = "Warning threshold for traffic SLO"
+  type        = number
+}
+
+variable "traffic_threshold_rpm" {
+  description = "Expected traffic threshold in requests per minute"
+  type        = number
+}
+
+variable "error_rate_target" {
+  description = "Target percentage for error rate SLO"
+  type        = number
+}
+
+variable "error_rate_warning" {
+  description = "Warning threshold for error rate SLO"
+  type        = number
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,21 +1,21 @@
 output "latency_slo_id" {
   description = "ID of the latency SLO"
-  value       = dynatrace_slo.todoservice_latency.id
+  value       = module.slo_service.latency.id
 }
 
 output "availability_slo_id" {
   description = "ID of the availability SLO"
-  value       = dynatrace_slo.todoservice_availability.id
+  value       = module.slo_service.availability.id
 }
 
 output "traffic_slo_id" {
   description = "ID of the traffic SLO"
-  value       = dynatrace_slo.todoservice_traffic.id
+  value       = module.slo_service.traffic.id
 }
 
 output "error_rate_slo_id" {
   description = "ID of the error rate SLO"
-  value       = dynatrace_slo.todoservice_errors.id
+  value       = module.slo_service.errors.id
 }
 
 output "slo_summary" {
@@ -24,23 +24,23 @@ output "slo_summary" {
     service_name = var.service_name
     slos = {
       latency = {
-        id     = dynatrace_slo.todoservice_latency.id
-        name   = dynatrace_slo.todoservice_latency.name
+        id     = module.slo_service.latency.id
+        name   = module.slo_service.latency.name
         target = var.latency_target
       }
       availability = {
-        id     = dynatrace_slo.todoservice_availability.id
-        name   = dynatrace_slo.todoservice_availability.name
+        id     = module.slo_service.availability.id
+        name   = module.slo_service.availability.name
         target = var.availability_target
       }
       traffic = {
-        id     = dynatrace_slo.todoservice_traffic.id
-        name   = dynatrace_slo.todoservice_traffic.name
+        id     = module.slo_service.traffic.id
+        name   = module.slo_service.traffic.name
         target = var.traffic_target
       }
       errors = {
-        id     = dynatrace_slo.todoservice_errors.id
-        name   = dynatrace_slo.todoservice_errors.name
+        id     = module.slo_service.errors.id
+        name   = module.slo_service.errors.name
         target = var.error_rate_target
       }
     }


### PR DESCRIPTION
## Summary
- add a reusable `slo_service` child module that provisions all LATE service SLOs
- update the root configuration to consume the module and expose the module outputs

## Testing
- not run (terraform CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfc374820c832a9b55fcae975d618c