### PR TITLE
Update Terraform lint workflow to use patch version

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.0"
+          terraform_version: "1.0.11"
 
       - name: Terraform Format Check
         id: fmt


### PR DESCRIPTION
## Summary
- update the Terraform setup action to pin Terraform 1.0.11 instead of the floating 1.0 constraint

## Testing
- not run (CI workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3a2232fc8832aa8acf2c5f05091fa