### PR TITLE
Update default synthetic location ID

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -101,5 +101,5 @@ variable "service_url" {
 variable "synthetic_locations" {
   description = "List of Dynatrace synthetic location IDs"
   type        = list(string)
-  default     = ["GEOLOCATION-9999999999999999"]
+  default     = ["GEOLOCATION-871416B95457AB88"]
 }


### PR DESCRIPTION
## Summary
- update the default Dynatrace synthetic location ID to the new GEOLOCATION-871416B95457AB88 value

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e6497ee2c4832ab19a9e55eef8a962