### PR TITLE
Add Site Reliability Guardian integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 # Dynatrace SLO Terraform - TodoService LATE Metrics
 
-This Terraform project manages Dynatrace SLOs based on the LATE metrics (Latency, Availability, Traffic, Errors) for the TodoService.
+This Terraform project manages Dynatrace SLOs based on the LATE metrics (Latency, Availability, Traffic, Errors) for the TodoService and links them to a Site Reliability Guardian policy.
 
 ## Overview
 
-The project creates four SLOs in Dynatrace:
+The project creates four SLOs in Dynatrace and (optionally) a Site Reliability Guardian that validates them before deployments:
 
 1. **Latency SLO** - Monitors response time performance
 2. **Availability SLO** - Tracks service uptime and success rate
 3. **Traffic SLO** - Measures request throughput
 4. **Error Rate SLO** - Monitors the percentage of failed requests
+5. **Site Reliability Guardian** - Aggregates the four SLOs into a deployment readiness check
 
 ## Prerequisites
 
 - Terraform >= 1.0
 - Dynatrace account with API access
-- Dynatrace API token with SLO write permissions
+- Dynatrace API token with SLO, Settings read/write permissions
 
 ### Creating a Dynatrace API Token
 
@@ -26,6 +27,8 @@ The project creates four SLOs in Dynatrace:
    - `slo.read`
    - `slo.write`
    - `metrics.read`
+   - `settings.read`
+   - `settings.write`
 5. Copy the generated token
 
 ## Setup
@@ -41,6 +44,7 @@ The project creates four SLOs in Dynatrace:
    - `dynatrace_environment_url`: Your Dynatrace environment URL
    - `dynatrace_api_token`: Your API token
    - Adjust SLO targets and thresholds as needed
+   - Optionally configure Site Reliability Guardian metadata
 
 4. Initialize Terraform:
    ```bash
@@ -81,6 +85,13 @@ All configurable variables are defined in `variables.tf`. Key variables include:
 #### Error Rate SLO
 - **error_rate_target**: Target % of successful requests (default: 99.5)
 
+#### Site Reliability Guardian
+- **enable_guardian**: Toggle guardian creation (default: `true`)
+- **guardian_name**: Override guardian name (default: `"<service_name> Guardian"`)
+- **guardian_description**: Optional description (default provides context)
+- **guardian_event_kind**: Storage type for evaluation events (`BIZ_EVENT` or `SDLC_EVENT`)
+- **guardian_tags**: Additional guardian tags (default: empty)
+
 ### Customization
 
 To modify SLO parameters:
@@ -99,7 +110,8 @@ service_name = "MyOtherService"
 After applying, Terraform outputs:
 
 - Individual SLO IDs for each metric
-- Summary object with all SLO details
+- Site Reliability Guardian ID (if enabled)
+- Summary object with all SLO and guardian details
 
 View outputs:
 ```bash
@@ -120,10 +132,12 @@ terraform output
 
 ```
 dynatrace-slo-terraform/
-├── main.tf                    # SLO resource definitions
+├── main.tf                    # SLO resources and Site Reliability Guardian
 ├── variables.tf               # Variable declarations
 ├── outputs.tf                 # Output definitions
 ├── terraform.tfvars.example   # Example configuration
+├── modules/
+│   └── slo_service/           # Module managing individual SLO resources and outputs
 └── README.md                  # Documentation
 ```
 

--- a/modules/slo_service/outputs.tf
+++ b/modules/slo_service/outputs.tf
@@ -29,3 +29,23 @@ output "errors" {
     name = dynatrace_slo.errors.name
   }
 }
+
+output "latency_metric_key" {
+  description = "Metric key for the latency SLO"
+  value       = "func:slo.${dynatrace_slo.latency.metric_name}"
+}
+
+output "availability_metric_key" {
+  description = "Metric key for the availability SLO"
+  value       = "func:slo.${dynatrace_slo.availability.metric_name}"
+}
+
+output "traffic_metric_key" {
+  description = "Metric key for the traffic SLO"
+  value       = "func:slo.${dynatrace_slo.traffic.metric_name}"
+}
+
+output "error_rate_metric_key" {
+  description = "Metric key for the error rate SLO"
+  value       = "func:slo.${dynatrace_slo.errors.metric_name}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,5 +44,15 @@ output "slo_summary" {
         target = var.error_rate_target
       }
     }
+    guardian = {
+      enabled = var.enable_guardian
+      id      = try(dynatrace_site_reliability_guardian.service[0].id, null)
+      name    = var.enable_guardian ? local.guardian_name : null
+    }
   }
+}
+
+output "guardian_id" {
+  description = "ID of the Site Reliability Guardian"
+  value       = try(dynatrace_site_reliability_guardian.service[0].id, null)
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -24,3 +24,10 @@ traffic_threshold_rpm = 100
 # Error Rate SLO Configuration
 error_rate_target  = 99.5
 error_rate_warning = 99.8
+
+# Site Reliability Guardian Configuration
+enable_guardian      = true
+guardian_name        = "TodoService Guardian"
+guardian_description = "Ensures SLO objectives remain within thresholds"
+guardian_event_kind  = "BIZ_EVENT"
+guardian_tags        = ["team:platform", "stage:staging"]

--- a/variables.tf
+++ b/variables.tf
@@ -103,3 +103,34 @@ variable "synthetic_locations" {
   type        = list(string)
   default     = ["GEOLOCATION-871416B95457AB88"]
 }
+
+# Site Reliability Guardian configuration
+variable "enable_guardian" {
+  description = "Whether to create a Site Reliability Guardian for the service"
+  type        = bool
+  default     = true
+}
+
+variable "guardian_name" {
+  description = "Optional override for the Site Reliability Guardian name"
+  type        = string
+  default     = null
+}
+
+variable "guardian_description" {
+  description = "Optional description for the Site Reliability Guardian"
+  type        = string
+  default     = null
+}
+
+variable "guardian_event_kind" {
+  description = "Event kind to use when recording guardian evaluations"
+  type        = string
+  default     = "BIZ_EVENT"
+}
+
+variable "guardian_tags" {
+  description = "Additional tags to attach to the Site Reliability Guardian"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary
- add a Site Reliability Guardian resource that evaluates the existing service SLOs
- expose configuration variables, outputs, and documentation so the guardian can be customized
- publish SLO metric keys from the module and extend the example tfvars for guardian settings

## Testing
- `terraform fmt -recursive` *(fails: terraform binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e64f1be244832abea54ae4643a2bdf