### PR TITLE
Fix Terraform lint workflow failure

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/dynatrace-oss/dynatrace" {
   constraints = "~> 1.0"
   hashes = [
     "h1:b54GRIetth8Ef51BtmqG6DcEdXlqVnsZrF/lfuqs54U=",
+    "h1:usdqViL0vlTiCVgUlXj2TT/k0Q16y9/+ABqBivIyaWQ=",
     "zh:066ee84b22ea324cc6eb796024e74c526997ca0b12c8ebca2db45ee4394c1596",
     "zh:0bafafe91289993227e65d9c501322396a2c68f72eed71180761f12f4a28c89c",
     "zh:315b9560946f9924c18b175f95bbe43b2056680d398c71c36448b1c9be29c7f0",

--- a/main.tf
+++ b/main.tf
@@ -22,19 +22,19 @@ locals {
 module "slo_service" {
   source = "./modules/slo_service"
 
-  service_name           = var.service_name
-  timeframe              = var.timeframe
-  latency_target         = var.latency_target
-  latency_warning        = var.latency_warning
-  latency_threshold_ms   = var.latency_threshold_ms
-  latency_percentile     = var.latency_percentile
-  availability_target    = var.availability_target
-  availability_warning   = var.availability_warning
-  traffic_target         = var.traffic_target
-  traffic_warning        = var.traffic_warning
-  traffic_threshold_rpm  = var.traffic_threshold_rpm
-  error_rate_target      = var.error_rate_target
-  error_rate_warning     = var.error_rate_warning
+  service_name          = var.service_name
+  timeframe             = var.timeframe
+  latency_target        = var.latency_target
+  latency_warning       = var.latency_warning
+  latency_threshold_ms  = var.latency_threshold_ms
+  latency_percentile    = var.latency_percentile
+  availability_target   = var.availability_target
+  availability_warning  = var.availability_warning
+  traffic_target        = var.traffic_target
+  traffic_warning       = var.traffic_warning
+  traffic_threshold_rpm = var.traffic_threshold_rpm
+  error_rate_target     = var.error_rate_target
+  error_rate_warning    = var.error_rate_warning
 }
 
 resource "dynatrace_site_reliability_guardian" "service" {


### PR DESCRIPTION
## Summary
- align the module input assignments in `main.tf` so `terraform fmt -check` succeeds
- refresh the Dynatrace provider lock file hashes after reinitializing Terraform

## Testing
- terraform fmt -check -recursive
- terraform init -backend=false
- terraform validate -no-color
- tflint --recursive --format compact

------
https://chatgpt.com/codex/tasks/task_e_68e65e605a68832a9512e7cf288aa4db